### PR TITLE
Store all channels in the same chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,49 +13,50 @@ pip install git+https://github.com/labsyspharm/cellcutter.git#egg=cellcutter
 ## Usage
 
 ```
-cut_cells [-h] [-p P] [--window-size WINDOW_SIZE]
-                 [--mask-cells | --dont-mask-cells] [--chunk-size CHUNK_SIZE]
-                 IMAGE SEGMENTATION_MASK CELL_DATA DESTINATION
+cut_cells [-h] [-p P] [-z] [--window-size WINDOW_SIZE] [--mask-cells]
+                 [--chunk-size CHUNK_SIZE] [--cache-size CACHE_SIZE]
                  [--channels [CHANNELS ...]]
+                 IMAGE SEGMENTATION_MASK CELL_DATA DESTINATION
 
 Cut out thumbnail images of all cells. Thumbnails will be stored as Zarr array
-(https://zarr.readthedocs.io/en/stable/index.html) with dimensions [#channels,
-#cells, window_size, window_size].
+(https://zarr.readthedocs.io/en/stable/index.html) with dimensions [#channels, #cells,
+window_size, window_size]. The chunking shape greatly influences performance
+https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations.
 
 positional arguments:
-  IMAGE                 Path to image in TIFF format, potentially with
-                        multiple channels. Thumbnails will be created from
-                        each channel.
-  SEGMENTATION_MASK     Path to segmentation mask image in TIFF format. Used
-                        to automatically chose window size and find cell
-                        outlines.
-  CELL_DATA             Path to CSV file with a row for each cell. Must
-                        contain columns CellID (must correspond to the cell
-                        IDs in the segmentation mask), Y_centroid, and
-                        X_centroid.
-  DESTINATION           Path to a new directory where cell thumbnails will be
-                        stored in Zarr format.
+  IMAGE                 Path to image in TIFF format, potentially with multiple
+                        channels. Thumbnails will be created from each channel.
+  SEGMENTATION_MASK     Path to segmentation mask image in TIFF format. Used to
+                        automatically chose window size and find cell outlines.
+  CELL_DATA             Path to CSV file with a row for each cell. Must contain columns
+                        CellID (must correspond to the cell IDs in the segmentation
+                        mask), Y_centroid, and X_centroid (the coordinates of cell
+                        centroids).
+  DESTINATION           Path to a new directory where cell thumbnails will be stored in
+                        Zarr format.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -p P                  Number of processes run in parallel.
-  -z                    Store thumbnails in a single zip file instead of a
-                        directory. (default: False)
+  -z                    Store thumbnails in a single zip file instead of a directory.
   --window-size WINDOW_SIZE
-                        Size of the cell thumbnail in pixels. Defaults to size
-                        of largest cell.
-  --mask-cells, --dont-mask-cells
-                        Fill every pixel not occupied by the target cell with
-                        zeros. (Default: --mask-cells) (default: True)
+                        Size of the cell thumbnail in pixels. Defaults to size of
+                        largest cell.
+  --mask-cells          Fill every pixel not occupied by the target cell with zeros.
   --chunk-size CHUNK_SIZE
-                        Desired uncompressed chunk size in MB.See https://zarr
-                        .readthedocs.io/en/stable/tutorial.html#chunk-
-                        optimizations. (Default: 32)
+                        Desired uncompressed chunk size in MB. (See
+                        https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-
+                        optimizations) Since the other chunk dimensions are fixed as
+                        [#channels, #cells, window_size, window_size], this argument
+                        determines the number of cells per chunk. (Default: 32 MB)
+  --cache-size CACHE_SIZE
+                        Cache size for reading image tiles in MB. For best performance
+                        the cache size should be larger than the size of the image.
+                        (Default: 10240 MB = 10 GB)
   --channels [CHANNELS ...]
-                        Indices of channels (1-based) to include in the output
-                        e.g., --channels 1 3 5. Default is to include all
-                        channels. This option has to *after* the positional
-                        arguments.
+                        Indices of channels (1-based) to include in the output e.g.,
+                        --channels 1 3 5. Default is to include all channels. This
+                        option must be *after* all positional arguments.
 ```
 
 ## Example
@@ -98,6 +99,98 @@ plt.tight_layout()
 ```
 
 ![png](docs/assets/example_thumbnails.png)
+
+## Performance
+
+Zarr arrays are [chunked](https://zarr.readthedocs.io/en/stable/tutorial.html?highlight=chunk#chunk-optimizations), meaning that they are split up into small pieces of equal size, and each chunk is stored in a separate file. Choice of the chunk size affects performance significantly.
+
+Performance will also vary quite a bit depending on the access pattern. Slicing the array so that only data from a single chunk needs to be read from disk will be fast while array slices that cross many chunks will be slow.
+
+An overview of some chunking performance considerations are [available here](https://www.oreilly.com/library/view/python-and-hdf5/9781491944981/ch04.html).
+
+By default, *cellcutter* creates Zarra arrays with chunks of the size `[channels in TIFF, x cells, thumbnail width, thumbnail height]`, meaning for a given cell, all channels and the entire thumbnail image are stored in the same chunk. The number of cells `x` per chunk is calculated internally so that each chunk has a total uncompressed size of about 32 MB.
+
+The default chunk size works well for access patterns that request all channels and the entire thumbnail for a given range of cells. Ideally, the cells should be contiguous along the second dimension of the array.
+
+```python
+import itertools
+import zarr
+import pandas as pd
+import numpy as np
+from matplotlib import pyplot as plt
+from numcodecs import Blosc
+```
+
+
+```python
+z = zarr.open("cellMaskThumbnails.zarr", mode="r")
+```
+
+
+```python
+z.shape
+```
+
+
+
+
+    (12, 9522, 46, 46)
+
+
+
+```python
+z.chunks
+```
+
+
+
+
+    (12, 330, 46, 46)
+
+
+
+The `chunks` property gives the size of each chunk in the array. In this example, all 12 channels, 330 cells, and the complete thumbnail are stored in a single chunk.
+
+### Access patterns
+
+#### 100 Random cells
+
+
+```python
+from numpy.random import default_rng
+rng = default_rng()
+def rand_slice(n=100):
+    return rng.choice(z.shape[1], size=n, replace=False)
+```
+
+
+```python
+%%timeit
+_ = z.get_orthogonal_selection((slice(None), rand_slice()))
+```
+
+    109 ms ± 2.9 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+
+#### 100 Contiguous cells
+
+
+```python
+%%timeit
+_ = z[:, 1000:1100, ...]
+```
+
+    4.13 ms ± 139 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+
+
+Accessing **100 random cells** from the Zarr array takes around 110 ms whereas accessing **100 contiguous cells** (cell 1000 to 1100) only takes around 4 ms — an almost 30-fold speed difference. This is because random cells are likely to be distributed across many separate chunks. All these chunks need to be read into memory in full even if only a single cell is requested for a given chunk. In contrast, contiguous cells are stored together in one or several neighboring chunks minimizing the amount of data that has to be read from disk.
+
+### Fast access to random cells
+
+If access to random cells is required, for example for training a machine learning model, there is a workaround avoiding the performance penalty of requesting random cells. Instead of truly accessing random cells we can instead randomize cell order before the Zarr array is created. Because cell order is random we can then simply request contiguous cells during training.
+
+The simplest way to randomize cell order is to shuffle the order of rows in the CSV file that is passed to *cellcutter*, for example by using *pandas* `df.sample(frac=1)`.
+
 
 ## Funding
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ pip install git+https://github.com/labsyspharm/cellcutter.git#egg=cellcutter
 
 ```
 cut_cells [-h] [-p P] [-z] [--window-size WINDOW_SIZE] [--mask-cells]
-                 [--chunk-size CHUNK_SIZE] [--cache-size CACHE_SIZE]
-                 [--channels [CHANNELS ...]]
+                 [--chunk-size CHUNK_SIZE | --cells-per-chunk CELLS_PER_CHUNK]
+                 [--cache-size CACHE_SIZE] [--channels [CHANNELS ...]]
                  IMAGE SEGMENTATION_MASK CELL_DATA DESTINATION
 
 Cut out thumbnail images of all cells. Thumbnails will be stored as Zarr array
@@ -24,39 +24,41 @@ window_size, window_size]. The chunking shape greatly influences performance
 https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations.
 
 positional arguments:
-  IMAGE                 Path to image in TIFF format, potentially with multiple
-                        channels. Thumbnails will be created from each channel.
-  SEGMENTATION_MASK     Path to segmentation mask image in TIFF format. Used to
-                        automatically chose window size and find cell outlines.
-  CELL_DATA             Path to CSV file with a row for each cell. Must contain columns
-                        CellID (must correspond to the cell IDs in the segmentation
-                        mask), Y_centroid, and X_centroid (the coordinates of cell
-                        centroids).
-  DESTINATION           Path to a new directory where cell thumbnails will be stored in
-                        Zarr format.
+  IMAGE                 Path to image in TIFF format, potentially with multiple channels.
+                        Thumbnails will be created from each channel.
+  SEGMENTATION_MASK     Path to segmentation mask image in TIFF format. Used to automatically
+                        chose window size and find cell outlines.
+  CELL_DATA             Path to CSV file with a row for each cell. Must contain columns CellID
+                        (must correspond to the cell IDs in the segmentation mask), Y_centroid,
+                        and X_centroid (the coordinates of cell centroids).
+  DESTINATION           Path to a new directory where cell thumbnails will be stored in Zarr
+                        format.
 
 options:
   -h, --help            show this help message and exit
   -p P                  Number of processes run in parallel.
   -z                    Store thumbnails in a single zip file instead of a directory.
   --window-size WINDOW_SIZE
-                        Size of the cell thumbnail in pixels. Defaults to size of
-                        largest cell.
+                        Size of the cell thumbnail in pixels. Defaults to size of largest cell.
   --mask-cells          Fill every pixel not occupied by the target cell with zeros.
   --chunk-size CHUNK_SIZE
                         Desired uncompressed chunk size in MB. (See
-                        https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-
-                        optimizations) Since the other chunk dimensions are fixed as
-                        [#channels, #cells, window_size, window_size], this argument
-                        determines the number of cells per chunk. (Default: 32 MB)
+                        https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations)
+                        Since the other chunk dimensions are fixed as [#channels, #cells,
+                        window_size, window_size], this argument determines the number of cells
+                        per chunk. (Default: 32 MB)
+  --cells-per-chunk CELLS_PER_CHUNK
+                        Desired number of cells stored per Zarr array chunk. By default this is
+                        determined automatically using the chunk size parameter. Setting this
+                        option overrides the chunk size parameter.
   --cache-size CACHE_SIZE
-                        Cache size for reading image tiles in MB. For best performance
-                        the cache size should be larger than the size of the image.
-                        (Default: 10240 MB = 10 GB)
+                        Cache size for reading image tiles in MB. For best performance the
+                        cache size should be larger than the size of the image. (Default: 10240 MB
+                        = 10 GB)
   --channels [CHANNELS ...]
-                        Indices of channels (1-based) to include in the output e.g.,
-                        --channels 1 3 5. Default is to include all channels. This
-                        option must be *after* all positional arguments.
+                        Indices of channels (1-based) to include in the output e.g., --channels 1
+                        3 5. Default is to include all channels. This option must be *after* all
+                        positional arguments.
 ```
 
 ## Example

--- a/benchmarking.ipynb
+++ b/benchmarking.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a34d377",
+   "metadata": {},
+   "source": [
+    "## Performance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e06323b",
+   "metadata": {},
+   "source": [
+    "Zarr arrays are [chunked](https://zarr.readthedocs.io/en/stable/tutorial.html?highlight=chunk#chunk-optimizations), meaning that they are split up into small pieces of equal size, and each chunk is stored in a separate file. Choice of the chunk size affects performance significantly.\n",
+    "\n",
+    "Performance will also vary quite a bit depending on the access pattern. Slicing the array so that only data from a single chunk needs to be read from disk will be fast while array slices that cross many chunks will be slow.\n",
+    "\n",
+    "An overview of some chunking performance considerations are [available here](https://www.oreilly.com/library/view/python-and-hdf5/9781491944981/ch04.html).\n",
+    "\n",
+    "By default, *cellcutter* creates Zarra arrays with chunks of the size `[channels in TIFF, x cells, thumbnail width, thumbnail height]`, meaning for a given cell, all channels and the entire thumbnail image are stored in the same chunk. The number of cells `x` per chunk is calculated internally so that each chunk has a total uncompressed size of about 32 MB.\n",
+    "\n",
+    "The default chunk size works well for access patterns that request all channels and the entire thumbnail for a given range of cells. Ideally, the cells should be contiguous along the second dimension of the array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b97b12c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import zarr\n",
+    "from numpy.random import default_rng"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1c37d308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z = zarr.open(\"cellMaskThumbnails.zarr\", mode=\"r\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a0df2199",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(12, 9522, 46, 46)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "z.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3cee9eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(12, 330, 46, 46)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "z.chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c13d733",
+   "metadata": {},
+   "source": [
+    "The `chunks` property gives the size of each chunk in the array. In this example, all 12 channels, 330 cells, and the complete thumbnail are stored in a single chunk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8ee14a3",
+   "metadata": {},
+   "source": [
+    "### Access patterns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dde9097",
+   "metadata": {},
+   "source": [
+    "#### 100 Random cells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "aece3312",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "rng = default_rng()\n",
+    "def rand_slice(n=100):\n",
+    "    return rng.choice(z.shape[1], size=n, replace=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5d889d75",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "109 ms ± 2.9 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "_ = z.get_orthogonal_selection((slice(None), rand_slice()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a94f744",
+   "metadata": {},
+   "source": [
+    "#### 100 Contiguous cells"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0e8c84fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.13 ms ± 139 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "_ = z[:, 1000:1100, ...]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1698c8ed",
+   "metadata": {},
+   "source": [
+    "Accessing **100 random cells** from the Zarr array takes around 110 ms whereas accessing **100 contiguous cells** (cell 1000 to 1100) only takes around 4 ms — an almost 30-fold speed difference. This is because random cells are likely to be distributed across many separate chunks. All these chunks need to be read into memory in full even if only a single cell is requested for a given chunk. In contrast, contiguous cells are stored together in one or several neighboring chunks minimizing the amount of data that has to be read from disk."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bf635ce",
+   "metadata": {},
+   "source": [
+    "### Fast access to random cells"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d6daeba",
+   "metadata": {},
+   "source": [
+    "If access to random cells is required, for example for training a machine learning model, there is a workaround avoiding the performance penalty of requesting random cells. Instead of truly accessing random cells we can instead randomize cell order before the Zarr array is created. Because cell order is random we can then simply request contiguous cells during training.\n",
+    "\n",
+    "The simplest way to randomize cell order is to shuffle the order of rows in the CSV file that is passed to *cellcutter*, for example by using *pandas* `df.sample(frac=1)`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarking.ipynb
+++ b/benchmarking.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7a34d377",
+   "id": "2f1f3a55",
    "metadata": {},
    "source": [
     "## Performance"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e06323b",
+   "id": "9aeb68ea",
    "metadata": {},
    "source": [
     "Zarr arrays are [chunked](https://zarr.readthedocs.io/en/stable/tutorial.html?highlight=chunk#chunk-optimizations), meaning that they are split up into small pieces of equal size, and each chunk is stored in a separate file. Choice of the chunk size affects performance significantly.\n",
@@ -19,7 +19,7 @@
     "\n",
     "An overview of some chunking performance considerations are [available here](https://www.oreilly.com/library/view/python-and-hdf5/9781491944981/ch04.html).\n",
     "\n",
-    "By default, *cellcutter* creates Zarra arrays with chunks of the size `[channels in TIFF, x cells, thumbnail width, thumbnail height]`, meaning for a given cell, all channels and the entire thumbnail image are stored in the same chunk. The number of cells `x` per chunk is calculated internally so that each chunk has a total uncompressed size of about 32 MB.\n",
+    "By default, *cellcutter* creates Zarr arrays with chunks of the size `[channels in TIFF, x cells, thumbnail width, thumbnail height]`, meaning for a given cell, all channels and the entire thumbnail image are stored in the same chunk. The number of cells `x` per chunk is calculated internally such that each chunk has a total uncompressed size of about 32 MB.\n",
     "\n",
     "The default chunk size works well for access patterns that request all channels and the entire thumbnail for a given range of cells. Ideally, the cells should be contiguous along the second dimension of the array."
    ]
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b97b12c1",
+   "id": "04eef733",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "1c37d308",
+   "id": "3163ecf9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "a0df2199",
+   "id": "3e347f96",
    "metadata": {},
    "outputs": [
     {
@@ -69,13 +69,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "3cee9eba",
+   "id": "2667e552",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(12, 330, 46, 46)"
+       "(12, 660, 46, 46)"
       ]
      },
      "execution_count": 4,
@@ -89,15 +89,19 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c13d733",
+   "id": "0531a2e2",
    "metadata": {},
    "source": [
-    "The `chunks` property gives the size of each chunk in the array. In this example, all 12 channels, 330 cells, and the complete thumbnail are stored in a single chunk."
+    "The `chunks` property gives the size of each chunk in the array. In this example, all 12 channels, 660 cells, and the complete thumbnail are stored in a single chunk.\n",
+    "\n",
+    "The number of cells per chunk is determined automatically by default and can be set directly using the `--cells-per-chunk` argument to *cellcutter* or alternatively indirectly using `--chunk-size`.\n",
+    "\n",
+    "Also here the number of cells per chunk should ideally be more or less in line with how many cells are requested in a typical array access operation."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b8ee14a3",
+   "id": "a2c49780",
    "metadata": {},
    "source": [
     "### Access patterns"
@@ -105,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dde9097",
+   "id": "346131a7",
    "metadata": {},
    "source": [
     "#### 100 Random cells"
@@ -114,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "aece3312",
+   "id": "a427dfdc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,14 +131,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "5d889d75",
+   "id": "6579d2e0",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "109 ms ± 2.9 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "101 ms ± 2.01 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -145,7 +149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a94f744",
+   "id": "5d639d7f",
    "metadata": {},
    "source": [
     "#### 100 Contiguous cells"
@@ -154,14 +158,14 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "0e8c84fe",
+   "id": "684738b3",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4.13 ms ± 139 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "5.81 ms ± 45.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -172,15 +176,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1698c8ed",
+   "id": "bd0c9395",
    "metadata": {},
    "source": [
-    "Accessing **100 random cells** from the Zarr array takes around 110 ms whereas accessing **100 contiguous cells** (cell 1000 to 1100) only takes around 4 ms — an almost 30-fold speed difference. This is because random cells are likely to be distributed across many separate chunks. All these chunks need to be read into memory in full even if only a single cell is requested for a given chunk. In contrast, contiguous cells are stored together in one or several neighboring chunks minimizing the amount of data that has to be read from disk."
+    "Accessing **100 random cells** from the Zarr array takes around 100 ms whereas accessing **100 contiguous cells** (cell 1000 to 1100) only takes around 6 ms — an almost 17-fold speed difference. This is because random cells are likely to be distributed across many separate chunks. All these chunks need to be read into memory in full even if only a single cell is requested for a given chunk. Given that this particular array happens to be split up into 15 chunks total the speed difference suggests that every request of 100 random cells results in all chunks being read from disk\n",
+    "\n",
+    "In contrast, contiguous cells are stored together in one or several neighboring chunks minimizing the amount of data that has to be read from disk."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7bf635ce",
+   "id": "da90bc29",
    "metadata": {},
    "source": [
     "### Fast access to random cells"
@@ -188,12 +194,81 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d6daeba",
+   "id": "7b1e868a",
    "metadata": {},
    "source": [
-    "If access to random cells is required, for example for training a machine learning model, there is a workaround avoiding the performance penalty of requesting random cells. Instead of truly accessing random cells we can instead randomize cell order before the Zarr array is created. Because cell order is random we can then simply request contiguous cells during training.\n",
+    "If access to random cells is required, for example for training a machine learning model, there is a workaround avoiding the performance penalty of requesting random cells. Instead of requesting a random slices of the array we can instead randomize cell order before the Zarr array is created. Because cell order is random we can then simply access a contiguous slice of cells during training.\n",
     "\n",
-    "The simplest way to randomize cell order is to shuffle the order of rows in the CSV file that is passed to *cellcutter*, for example by using *pandas* `df.sample(frac=1)`."
+    "The simplest way to randomize cell order is to shuffle the order of rows in the CSV file that is passed to *cellcutter*, for example by using *pandas* `df.sample(frac=1)`.\n",
+    "\n",
+    "A training loop using cell thumbnails created with this method could look something like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1762f936",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from timeit import default_timer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "901684b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iteration 0 training using cells (0, 500) validating using cells (500, 600) loading images took 0.018s\n",
+      "Iteration 1 training using cells (600, 1100) validating using cells (1100, 1200) loading images took 0.03s\n",
+      "Iteration 2 training using cells (1200, 1700) validating using cells (1700, 1800) loading images took 0.024s\n",
+      "Iteration 3 training using cells (1800, 2300) validating using cells (2300, 2400) loading images took 0.023s\n",
+      "Iteration 4 training using cells (2400, 2900) validating using cells (2900, 3000) loading images took 0.023s\n",
+      "Iteration 5 training using cells (3000, 3500) validating using cells (3500, 3600) loading images took 0.023s\n",
+      "Iteration 6 training using cells (3600, 4100) validating using cells (4100, 4200) loading images took 0.023s\n",
+      "Iteration 7 training using cells (4200, 4700) validating using cells (4700, 4800) loading images took 0.023s\n",
+      "Iteration 8 training using cells (4800, 5300) validating using cells (5300, 5400) loading images took 0.023s\n",
+      "Iteration 9 training using cells (5400, 5900) validating using cells (5900, 6000) loading images took 0.027s\n",
+      "Iteration 10 training using cells (6000, 6500) validating using cells (6500, 6600) loading images took 0.02s\n",
+      "Iteration 11 training using cells (6600, 7100) validating using cells (7100, 7200) loading images took 0.019s\n",
+      "Iteration 12 training using cells (7200, 7700) validating using cells (7700, 7800) loading images took 0.023s\n",
+      "Iteration 13 training using cells (7800, 8300) validating using cells (8300, 8400) loading images took 0.023s\n",
+      "Iteration 14 training using cells (8400, 8900) validating using cells (8900, 9000) loading images took 0.025s\n"
+     ]
+    }
+   ],
+   "source": [
+    "csv = pd.read_csv(\"exemplar-001/quantification/unmicst-exemplar-001_cellMask.csv\")\n",
+    "P = 0.2\n",
+    "\n",
+    "# batch sizes\n",
+    "batch_size_train = 500\n",
+    "batch_size_valid = round(batch_size_train * P)\n",
+    "\n",
+    "# training loop\n",
+    "for i, s in enumerate(\n",
+    "    range(0, len(csv) - batch_size_train - batch_size_valid, batch_size_train + batch_size_valid)\n",
+    "):\n",
+    "    # construct training and validation slices\n",
+    "    train_slice = (s, s + batch_size_train)\n",
+    "    valid_slice = (train_slice[1], train_slice[1] + batch_size_valid)\n",
+    "    # get training and validation thumbnails\n",
+    "    start_time = default_timer()\n",
+    "    x_train = z[:, train_slice[0]:train_slice[1], ...]\n",
+    "    x_valid = z[:, valid_slice[0]:valid_slice[1], ...]\n",
+    "    end_time = default_timer()\n",
+    "    print(\n",
+    "        f\"Iteration {i} training using cells {train_slice}\",\n",
+    "        f\"validating using cells {valid_slice}\",\n",
+    "        f\"loading images took {round(end_time - start_time, 3)}s\"\n",
+    "    )\n",
+    "    # Do training"
    ]
   }
  ],

--- a/cellcutter/cli.py
+++ b/cellcutter/cli.py
@@ -60,7 +60,8 @@ def cut():
         action="store_true",
         help="Fill every pixel not occupied by the target cell with zeros.",
     )
-    parser.add_argument(
+    chunk_size_group = parser.add_mutually_exclusive_group()
+    chunk_size_group.add_argument(
         "--chunk-size",
         default=32,
         type=int,
@@ -68,6 +69,14 @@ def cut():
         "(See https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations) "
         "Since the other chunk dimensions are fixed as [#channels, #cells, window_size, window_size], "
         "this argument determines the number of cells per chunk. (Default: 32 MB)",
+    )
+    chunk_size_group.add_argument(
+        "--cells-per-chunk",
+        default=None,
+        type=int,
+        help="Desired number of cells stored per Zarr array chunk. By default this is "
+        "determined automatically using the chunk size parameter. Setting this option "
+        "overrides the chunk size parameter.",
     )
     parser.add_argument(
         "--cache-size",
@@ -112,6 +121,7 @@ def cut():
         mask_cells=args.mask_cells,
         processes=args.p,
         target_chunk_size=args.chunk_size * 1024 * 1024,
+        cells_per_chunk=args.cells_per_chunk,
         channels=channels,
         use_zip=args.z,
         cache_size=args.cache_size * 1024 * 1024,

--- a/cellcutter/cli.py
+++ b/cellcutter/cli.py
@@ -8,49 +8,6 @@ import pandas as pd
 from . import cut as cut_mod
 
 
-class BooleanOptionalAction(argparse.Action):
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        default=None,
-        type=None,
-        choices=None,
-        required=False,
-        help=None,
-        metavar=None,
-        prefix="--dont-",
-    ):
-        self.prefix = prefix
-        _option_strings = []
-        for option_string in option_strings:
-            _option_strings.append(option_string)
-
-            if option_string.startswith("--"):
-                option_string = prefix + option_string[2:]
-                _option_strings.append(option_string)
-        if help is not None and default is not None:
-            help += f" (Default: {default})"
-        super().__init__(
-            option_strings=_option_strings,
-            dest=dest,
-            nargs=0,
-            default=default,
-            type=type,
-            choices=choices,
-            required=required,
-            help=help,
-            metavar=metavar,
-        )
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string in self.option_strings:
-            setattr(namespace, self.dest, not option_string.startswith(self.prefix))
-
-    def format_usage(self):
-        return " | ".join(self.option_strings)
-
-
 def cut():
     parser = argparse.ArgumentParser(
         description="""Cut out thumbnail images of all cells.
@@ -58,7 +15,8 @@ def cut():
         Thumbnails will be stored as Zarr array (https://zarr.readthedocs.io/en/stable/index.html)
         with dimensions [#channels, #cells, window_size, window_size].
 
-        The chunking shape greatly influences performance  ttps://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations.
+        The chunking shape greatly influences performance
+        https://zarr.readthedocs.io/en/stable/tutorial.html#chunk-optimizations.
         """,
     )
     parser.add_argument(
@@ -74,7 +32,8 @@ def cut():
     parser.add_argument(
         "CELL_DATA",
         help="Path to CSV file with a row for each cell. Must contain columns CellID "
-        "(must correspond to the cell IDs in the segmentation mask), Y_centroid, and X_centroid.",
+        "(must correspond to the cell IDs in the segmentation mask), Y_centroid, and X_centroid "
+        "(the coordinates of cell centroids).",
     )
     parser.add_argument(
         "DESTINATION",
@@ -86,7 +45,7 @@ def cut():
     parser.add_argument(
         "-z",
         default=False,
-        action=BooleanOptionalAction,
+        action="store_true",
         help="Store thumbnails in a single zip file instead of a directory.",
     )
     parser.add_argument(
@@ -97,8 +56,8 @@ def cut():
     )
     parser.add_argument(
         "--mask-cells",
-        default=True,
-        action=BooleanOptionalAction,
+        default=False,
+        action="store_true",
         help="Fill every pixel not occupied by the target cell with zeros.",
     )
     parser.add_argument(
@@ -114,7 +73,9 @@ def cut():
         "--cache-size",
         default=10 * 1024,
         type=int,
-        help="Cache size for reading image tiles in MB. (Default: 10 * 1024 MB)",
+        help="Cache size for reading image tiles in MB. For best performance the cache "
+        "size should be larger than the size of the image. "
+        "(Default: 10240 MB = 10 GB)",
     )
     parser.add_argument(
         "--channels",

--- a/cellcutter/cut.py
+++ b/cellcutter/cut.py
@@ -175,13 +175,17 @@ def process_all_channels(
             compressor=Blosc(cname="zstd", clevel=2, shuffle=Blosc.SHUFFLE),
             chunks=(array_chunks[1], array_chunks[2], array_chunks[3]),
         )
+        mask_thumbnails_temp = np.empty(
+            (cell_data.shape[0], window_size, window_size), dtype=np.bool_,
+        )
         cut_cells(
             segmentation_mask_img,
             cell_data,
             window_size,
-            mask_thumbnails,
+            mask_thumbnails_temp,
             create_mask_thumbnails=True,
         )
+        mask_thumbnails[...] = mask_thumbnails_temp[...]
         # If writing to zip files was requested zipping up the directory now
         if use_zip:
             logging.debug(f"Zipping up mask to {destination_mask}")

--- a/cellcutter/cut.py
+++ b/cellcutter/cut.py
@@ -108,6 +108,7 @@ def process_all_channels(
     mask_cells: bool = True,
     processes: int = 1,
     target_chunk_size: int = 32 * 1024 * 1024,
+    cells_per_chunk: Optional[int] = None,
     channels: Optional[Iterable[int]] = None,
     use_zip: bool = False,
     cache_size: int = 1024 * 1024 * 1024,
@@ -141,9 +142,12 @@ def process_all_channels(
     if channels[0] < 0 or channels[-1] >= img.n_channels:
         raise ValueError(f"Channel indices must be between 0 and {img.n_channels - 1}.")
     array_shape = (len(channels), cell_data.shape[0], window_size, window_size)
-    array_chunks = find_chunk_size(
-        array_shape, np.dtype(img.dtype).itemsize, target_bytes=target_chunk_size
-    )
+    if cells_per_chunk is None:
+        array_chunks = find_chunk_size(
+            array_shape, np.dtype(img.dtype).itemsize, target_bytes=target_chunk_size
+        )
+    else:
+        array_chunks = tuple(int(x) for x in (len(channels), cells_per_chunk, window_size, window_size))
     logging.info(f"Using chunks of shape {array_chunks}")
     # If writing to a zip file, create a temporary directory to store the zarr files
     # and compress them into the zip file at the end. Solves issues with concurrent

--- a/cellcutter/utils.py
+++ b/cellcutter/utils.py
@@ -1,0 +1,89 @@
+import itertools
+import pathlib
+import zipfile
+from typing import Union, Tuple
+
+import numpy as np
+import tifffile
+import zarr
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+def range_all(start, stop, step):
+    "Like range() but with stop included"
+    for i in range(start, stop, step):
+        yield i
+    yield stop
+
+
+def zip_dir(dir: Union[pathlib.Path, str], zip_file: Union[pathlib.Path, str]) -> None:
+    "Zip the contents of the given directory into a ZIP file."
+    dir = pathlib.Path(dir)
+    # Don't compress the ZIP file. Zarr arrays are already compressed.
+    with zipfile.ZipFile(zip_file, "w", compression=zipfile.ZIP_STORED) as zf:
+        for f in dir.rglob("*"):
+            zf.write(f, f.relative_to(dir))
+
+
+def padded_subset(img: Union[zarr.Array, np.ndarray], x: int, y: int, window_size: Tuple[int, int]) -> np.ndarray:
+    "Return a subset of the image with the given window size padded with zero if window is partially outside the image"
+    wh = img.shape[-2:]
+    s = (
+        (x - window_size[0] // 2, x + window_size[0] - window_size[0] // 2),
+        (y - window_size[1] // 2, y + window_size[1] - window_size[1] // 2),
+    )
+    s_img = (
+        (max(0, s[0][0]), min(wh[0], s[0][1])),
+        (max(0, s[1][0]), min(wh[1], s[1][1])),
+    )
+    s_out = (
+        (
+            max(0, -s[0][0]),
+            min(window_size[0], window_size[0] - s[0][1] + wh[0]),
+        ),
+        (
+            max(0, -s[1][0]),
+            min(window_size[1], window_size[1] - s[1][1] + wh[1]),
+        ),
+    )
+    out = np.zeros(
+        img.shape[:-2] + (window_size[0], window_size[1]), dtype=img.dtype
+    )
+    out[..., s_out[0][0] : s_out[0][1], s_out[1][0] : s_out[1][1]] = img[
+        ..., s_img[0][0] : s_img[0][1], s_img[1][0] : s_img[1][1]
+    ]
+    return out
+
+
+class Image:
+    def __init__(self, path: str, cache_size: int = 1024 * 1024 * 1024):
+        self.path = path
+        self.image = tifffile.TiffFile(path)
+        self.base_series = self.image.series[0]
+        self.cache_size = cache_size
+        self.zarr = zarr.open(
+            zarr.LRUStoreCache(self.image.aszarr(series=0), self.cache_size), mode="r"
+        )
+
+    def get_channel(self, channel_index: int) -> np.ndarray:
+        return self.base_series.pages[channel_index].asarray()
+
+    @property
+    def width_height(self) -> Tuple[int, int]:
+        return tuple(self.base_series.shape)[-2:]
+
+    @property
+    def n_channels(self) -> int:
+        if len(self.base_series.shape) == 2:
+            return 1
+        else:
+            return self.base_series.shape[0]
+
+    @property
+    def dtype(self):
+        return self.base_series.dtype

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cellcutter
-version = 0.1.2
+version = 0.2.0
 
 [options]
 packages = cellcutter

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ install_requires =
     tifffile
     zarr
     numcodecs
-python_requires = >= 3.7
+python_requires = >= 3.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Based on feedback we received on the performance of the Zarr arrays created by cellcutter we decided to change the chunk shape, so that all image channels for a given cell are stored in the same chunk.