### PR TITLE
Support BioFormats 6 pyramid encoding

### DIFF
--- a/cellcutter/cut.py
+++ b/cellcutter/cut.py
@@ -203,7 +203,8 @@ def process_all_channels(
     ) as executor, SharedMemoryManager() as smm:
         if n_bytes_img < cache_size:
             logging.info(
-                f"Image size {n_bytes_img} is smaller than cache size {cache_size}. "
+                f"Image size ({round(n_bytes_img / 1024**2)} MB) is smaller "
+                f"than cache size ({round(cache_size / 1024**2)} MB). "
                 "Loading entire image into memory."
             )
             raw_sm = smm.SharedMemory(size=n_bytes_img)
@@ -225,8 +226,9 @@ def process_all_channels(
                 for cell_range in pairwise(range_all(0, n_cells, array_chunks[1]))
             }
         else:
-            logging.info(
-                f"Image size {n_bytes_img} is larger than cache size {cache_size}. "
+            logging.warn(
+                f"Image size ({round(n_bytes_img / 1024**2)} MB) is larger than "
+                f"cache size ({round(cache_size / 1024**2)} MB). "
                 "This results in many reads from disk and will be slow. Consider "
                 "increasing the cache size."
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cellcutter
-version = 0.2.0
+version = 0.2.1
 
 [options]
 packages = cellcutter


### PR DESCRIPTION
Fix bug where images using the new BioFormats 6 OME-TIFF pyramid format couldn't be processed. From now on only support images in the new format.
Upgrade images using https://github.com/labsyspharm/ome-tiff-pyramid-tools/blob/master/pyramid_upgrade.py