### PR TITLE
Preserve channel order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ positional arguments:
                         chose window size and find cell outlines.
   CELL_DATA             Path to CSV file with a row for each cell. Must contain columns CellID
                         (must correspond to the cell IDs in the segmentation mask), Y_centroid,
-                        and X_centroid (the coordinates of cell centroids).
+                        and X_centroid (the coordinates of cell centroids). Only cells represented
+                        in the given CSV file will be used, even if additional cells are present
+                        in the segmentation mask. Cells are written to the file in the same order
+                        as they appear in the CSV file.
   DESTINATION           Path to a new directory where cell thumbnails will be stored in Zarr
                         format.
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -p P                  Number of processes run in parallel.
   -z                    Store thumbnails in a single zip file instead of a directory.
@@ -52,13 +55,14 @@ options:
                         determined automatically using the chunk size parameter. Setting this
                         option overrides the chunk size parameter.
   --cache-size CACHE_SIZE
-                        Cache size for reading image tiles in MB. For best performance the
-                        cache size should be larger than the size of the image. (Default: 10240 MB
-                        = 10 GB)
+                        Cache size for reading image tiles in MB. For best performance the cache
+                        size should be larger than the size of the image. (Default: 10240 MB = 10
+                        GB)
   --channels [CHANNELS ...]
                         Indices of channels (1-based) to include in the output e.g., --channels 1
-                        3 5. Default is to include all channels. This option must be *after* all
-                        positional arguments.
+                        3 5. Channels are included in the file in the given order. If not
+                        specified, by default all channels are included. This option must be
+                        *after* all positional arguments.
 ```
 
 ## Example

--- a/cellcutter/__init__.py
+++ b/cellcutter/__init__.py
@@ -1,0 +1,1 @@
+from .cut import process_image

--- a/cellcutter/cut.py
+++ b/cellcutter/cut.py
@@ -1,7 +1,7 @@
 import logging
 import concurrent.futures
-from operator import inv
 import pathlib
+import warnings
 from typing import Optional, Union, Iterable, Tuple
 from multiprocessing.shared_memory import SharedMemory
 from multiprocessing.managers import SharedMemoryManager
@@ -13,6 +13,19 @@ from numcodecs import Blosc
 from skimage.measure import regionprops_table
 
 from .utils import padded_subset, range_all, pairwise, zip_dir, Image
+
+
+class DuplicateChannelWarning(Warning):
+    def __init__(self, *args, **kwargs):
+        channels = kwargs.pop("duplicate_channels")
+        super().__init__(*args, **kwargs)
+        self.duplicate_channels = channels
+
+    def __str__(self):
+        return (
+            "The given channels are not unique. "
+            f"Channels {' '.join(str(x) for x in self.duplicate_channels)} will appear more than once in the output file."
+        )
 
 
 def cut_cells(
@@ -129,12 +142,12 @@ def find_chunk_size(
     return tuple(int(x) for x in (shape[0], cells_per_chunk, shape[2], shape[3]))
 
 
-def process_all_channels(
-    img: Image,
-    segmentation_mask: Image,
+def process_image(
+    img: Union[str, Image],
+    segmentation_mask: Union[str, Image],
     cell_data: pd.DataFrame,
     destination: Union[pathlib.Path, str],
-    window_size: Optional[int],
+    window_size: Optional[int] = None,
     mask_cells: bool = True,
     processes: int = 1,
     target_chunk_size: int = 32 * 1024 * 1024,
@@ -144,22 +157,33 @@ def process_all_channels(
     cache_size: int = 1024 * 1024 * 1024,
 ) -> None:
     "Given an image, segmentation mask, and cell positions, cut out cells and write a stack of cell thumbnails in Zarr format."
+    if not isinstance(img, Image):
+        img = Image(img)
+    if not isinstance(segmentation_mask, Image):
+        segmentation_mask = Image(segmentation_mask)
     destination = pathlib.Path(destination)
     if use_zip:
         destination = destination.with_suffix(".zip")
     logging.info("Loading segmentation mask")
     segmentation_mask_img = segmentation_mask.get_channel(0)
-    # Check if all cell IDs present in the CSV file are also represented in the segmentation mask
-    logging.info("Check consistency of cell IDs")
-    cell_ids_not_in_segmentation_mask = np.in1d(cell_data["CellID"], segmentation_mask_img, invert=True)
+    logging.info(
+        "Check if all cell IDs from the CSV are represented in the segmentation mask"
+    )
+    cell_ids_not_in_segmentation_mask = np.in1d(
+        cell_data["CellID"], segmentation_mask_img, invert=True
+    )
     n_not_in_segmentation_mask = np.sum(cell_ids_not_in_segmentation_mask)
-    del cell_ids_not_in_segmentation_mask
     if n_not_in_segmentation_mask > 0:
         raise ValueError(
-            f"{n_not_in_segmentation_mask} cell IDs in the CELL_DATA CSV file are not present in the segmentation mask."
+            f"{n_not_in_segmentation_mask} cell IDs in the CELL_DATA CSV file are not represented in the segmentation mask. "
+            "Please check that the segmentation mask contains all cell IDs present in the CSV file. "
+            f"The first 10 problematic IDs are {' '.join(str(x) for x in cell_data['CellID'][cell_ids_not_in_segmentation_mask][:10])}"
         )
+    del cell_ids_not_in_segmentation_mask
     logging.info("Remove cells from segmentation mask that are not present in the CSV")
-    segmentation_mask_img[np.isin(segmentation_mask_img, cell_data["CellID"], invert=True)] = 0
+    segmentation_mask_img[
+        np.isin(segmentation_mask_img, cell_data["CellID"], invert=True)
+    ] = 0
     if window_size is None:
         logging.info("Finding window size")
         window_size = find_bbox_size(segmentation_mask_img)
@@ -167,8 +191,11 @@ def process_all_channels(
     if channels is None:
         channels = np.arange(img.n_channels)
     else:
-        channels = np.unique(np.array(channels))
-    if channels[0] < 0 or channels[-1] >= img.n_channels:
+        if len(channels) != len(set(channels)):
+            vals, counts = np.unique(channels, return_counts=True)
+            warnings.warn(DuplicateChannelWarning(duplicate_channels=vals[counts > 1]))
+        channels = np.array(channels)
+    if np.min(channels) < 0 or np.max(channels) >= img.n_channels:
         raise ValueError(f"Channel indices must be between 0 and {img.n_channels - 1}.")
     array_shape = (len(channels), cell_data.shape[0], window_size, window_size)
     if cells_per_chunk is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cellcutter
-version = 0.2.3
+version = 0.2.4
 
 [options]
 packages = cellcutter

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cellcutter
-version = 0.2.2
+version = 0.2.3
 
 [options]
 packages = cellcutter


### PR DESCRIPTION
Previously, the user-supplied list of channels was silently sorted and de-duplicated. The new behavior is to preserve the given channel order and warn the user when duplicate channels are requested, but include them regardless.