### PR TITLE
Support standard TIFF files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cellcutter
-version = 0.2.5
+version = 0.2.6
 url = https://github.com/labsyspharm/cellcutter
 author = Clemens Hug
 license = MIT


### PR DESCRIPTION
Support any TIFF files, not just those conforming to BioFormats 6 OME-TIFF specification. Assume that first series in TIFF file contains the relevant image and the first group, if present.